### PR TITLE
fix: Add map module import to loss.lua

### DIFF
--- a/gameplay/loss.lua
+++ b/gameplay/loss.lua
@@ -5,6 +5,7 @@ local card = require "gameplay.card"
 local sync = require "gameplay.sync"
 local loadsave = require "core.loadsave"
 local track = require "gameplay.track"
+local map = require "gameplay.map"
 
 local function clear(where)
 	local n = 1


### PR DESCRIPTION
失败阶段，重置游戏卡住了，原因是访问了未定义的 map 变量