### PR TITLE
fix(core/keyboard): skip control chars

### DIFF
--- a/core/keyboard.lua
+++ b/core/keyboard.lua
@@ -71,8 +71,11 @@ function keyboard.setup(callback)
 			end
 		end
 	end
+	local function is_control_char(codepoint)
+		return codepoint < 32 or (codepoint >= 127 and codepoint <= 159)
+	end
 	function callback.char(codepoint)
-		if CURRENT_EDITBOX then
+		if CURRENT_EDITBOX and not is_control_char(codepoint) then
 			local c = utf8.char(codepoint)
 			CURRENT_EDITBOX.input = (CURRENT_EDITBOX.input or "") .. c
 		end


### PR DESCRIPTION
在 macOS 中，Backspace 按键操作会发送0x7F字符，导致命名出现不可见内容占据宽度，造成删除失败。
新增了检查函数跳过所有控制符