### PR TITLE
fix(core/keyboard): ime position use top-left origin

### DIFF
--- a/core/keyboard.lua
+++ b/core/keyboard.lua
@@ -107,7 +107,7 @@ function keyboard.editbox(desc)
 			cx, cy, cw, ch, cursor = desc.cursor_get(text, cursor, width, height)
 			desc.label = nil
 		end
-		app.set_ime_rect(cx+desc.ime_x, -cy+desc.ime_y, cw, ch)
+		app.set_ime_rect(cx+desc.ime_x, cy+desc.ime_y-ch, cw, ch)
 		app.set_ime_font(desc.fontname, desc.fontsize)
 		desc.cursor = cursor
 		desc.text = text

--- a/gameplay/cardlist.lua
+++ b/gameplay/cardlist.lua
@@ -105,7 +105,6 @@ local can_edit = {
 
 local function edit(text, x, y, w, h, list, editbox, item)
 	local attribs = editbox:attribs()
-	local _, view_h = vdesktop.screen_size()
 	local fontid = lang.font_id()
 	local fontsize = attribs.size or 16	-- see widget
 	local fontattr = font.size(fontid, fontsize)
@@ -118,7 +117,7 @@ local function edit(text, x, y, w, h, list, editbox, item)
 		width = w,
 		height = h,
 		ime_x = x + list.x,
-		ime_y = view_h - (y + list.y + fontattr.ascent),
+		ime_y = y + list.y + fontattr.ascent,
 	}
 	local list_n = #list + 1
 	local text_label = {

--- a/visual/desktop.lua
+++ b/visual/desktop.lua
@@ -207,12 +207,8 @@ layouts.hud = hud
 layouts.describe = describe
 local SCREEN_CX = 0
 local SCREEN_CY = 0
-local SCREEN_WIDTH = 0
-local SCREEN_HEIGHT = 0
 
 local function set_hud(w, h)
-	SCREEN_WIDTH = w
-	SCREEN_HEIGHT = h
 	SCREEN_CX = w / 2	-- center of screen
 	SCREEN_CY = h / 2
 	for i = 1, #layouts do
@@ -599,10 +595,6 @@ function M.describe_layout()
 		left = { widget.get("describe", "left"):get() },
 		right = { widget.get("describe", "right"):get() },
 	}
-end
-
-function M.screen_size()
-	return SCREEN_WIDTH, SCREEN_HEIGHT
 end
 
 return M


### PR DESCRIPTION
前置 PR: https://github.com/cloudwu/soluna/pull/24

将坐标系改成 top-left