### PR TITLE
fix(visual/desktop): centering layout while full screen

### DIFF
--- a/visual/desktop.lua
+++ b/visual/desktop.lua
@@ -566,9 +566,9 @@ function M.init(args)
 	local width = args.width
 	local height = args.height
 	function update_draw_list(w, h)
-		w = w or width
-		h = h or height
-		set_hud(w, h)
+		width = w or width
+		height = h or height
+		set_hud(width, height)
 		for i = 1, #layouts do
 			local name = layouts[i]
 			DRAWLIST[name] = widget.draw_list(name, layouts[name], FONT_ID, SPRITES)


### PR DESCRIPTION
全屏模式下，只有一帧是居中的，后续渲染就会移动到左上角。将其修复保持居中状态。