### PR TITLE
fix(platform/wasm): broken font

### DIFF
--- a/localization/setting.dl
+++ b/localization/setting.dl
@@ -6,7 +6,7 @@ setting :
 		font :
 			微软雅黑
 			"Yuanti SC"
-			文泉驿微米黑
+			"WenQuanYi Micro Hei"
 		timefmt : "%Y/%m/%d %H:%M"
 		homepage : "https://blog.codingnow.com/2025/07/deep_future.html"
 	english:


### PR DESCRIPTION
文泉驿的字体名称写错了, 导致 web 版报错