### PR TITLE
fix(platform/wasm): invalid font on macOS browser

### DIFF
--- a/.github/assets/index.html
+++ b/.github/assets/index.html
@@ -398,7 +398,7 @@
       'Helvetica'
     ];
     const CHINESE_FONT_POSTSCRIPT_NAMES = [
-      'STHeiti',
+      'STYuanti-SC-Regular',
       'MicrosoftYaHei',
       'HeitiSC',
     ];

--- a/localization/setting.dl
+++ b/localization/setting.dl
@@ -4,14 +4,13 @@ setting :
 		english_name : "Simplified Chinese"
 		fontfile :
 			asset/font/MicrosoftYaHei.ttf
-			asset/font/STHeiti.ttf
+			asset/font/STYuanti-SC-Regular.ttf
 			asset/font/HeitiSC.ttf
 			asset/font/SourceHanSansSC-Regular.ttf
 		font :
 			微软雅黑
 			"Microsoft YaHei"
 			"Yuanti SC"
-			"STHeiti"
 			"Heiti SC"
 			"Source Han Sans SC Regular"
 			"WenQuanYi Micro Hei"


### PR DESCRIPTION
修复 macOS 浏览器下字体不可用的问题，改为 YuanTiSC