### PR TITLE
chore: use linear filter for text sampler by default

### DIFF
--- a/main.game
+++ b/main.game
@@ -4,3 +4,6 @@ width : 1024
 height : 768
 high_dpi : true
 soluna : 3
+text_sampler :
+	min_filter : linear
+	mag_filter : linear


### PR DESCRIPTION
默认启用 text_sampler 配置